### PR TITLE
2nd draft of adding lockfile to singlerun

### DIFF
--- a/torDOTcom_pitstop_input.rb
+++ b/torDOTcom_pitstop_input.rb
@@ -69,7 +69,7 @@ this_pitstop_dir = File.join("P:", "#{project_dir}_POD#{staging}", "input")
 # choose pitstop_dir by project, if folder doesn't exist for this project default to SMP_POD
 pitstop_dir = setPitstopDir(this_pitstop_dir, staging, 'set_pitstop_dir')
 
-input_filename = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "#{Metadata.pisbn}_POD.pdf")
+input_filename = File.join(Metadata.final_dir, "#{Metadata.pisbn}_POD.pdf")
 pitstop_filename = File.join(pitstop_dir, "#{project_dir}_#{stage_dir}-#{Metadata.pisbn}.pdf")
 @log_hash['pitstop_filename'] = pitstop_filename
 

--- a/torDOTcom_pitstop_output.rb
+++ b/torDOTcom_pitstop_output.rb
@@ -115,9 +115,9 @@ this_pitstop_dir = File.join("P:", "#{project_dir}_POD#{staging}", "done")
 # choose pitstop_dir by project, if folder doesn't exist for this project default to SMP_POD
 pitstop_dir = setPitstopDir(this_pitstop_dir, staging, 'set_pitstop_dir')
 
-input_filename = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "#{Metadata.pisbn}_POD.pdf")
+input_filename = File.join(Metadata.final_dir, "#{Metadata.pisbn}_POD.pdf")
 pitstop_filename = File.join(pitstop_dir, "#{project_dir}_#{stage_dir}-#{Metadata.pisbn}.pdf")
-pitstop_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "PITSTOP_ERROR.txt")
+pitstop_error = File.join(Metadata.final_dir, "PITSTOP_ERROR.txt")
 
 # rm existing pitstrop_errfile if exists (from prior run(s))
 rmFile(pitstop_error, 'rm_pitstop_error_file')


### PR DESCRIPTION
1 of a set of 5 PR's to handle concurrent bookmaker runs, both with the tmpdir & the done_dir.
Straightforward unless a 'locked' done dir for the exact same ISBN exists, then it retries every minute for 15 minutes, then spawns a new done_dir with an error.txt in the root.
Repos affected:
bookmaker (https://github.com/macmillanpublishers/bookmaker/pull/216)
bookmaker_addons (macmillanpublishers/bookmaker_addons#203)
bookmaker_connectors
pitstop_watch
covermaker